### PR TITLE
add utterances support and use my own theme fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/ghostwriter"]
 	path = themes/ghostwriter
-	url = https://github.com/jbub/ghostwriter.git
+	url = https://github.com/markally/ghostwriter.git

--- a/config.toml
+++ b/config.toml
@@ -35,6 +35,7 @@ copyright = "Mark Ally"  # ghostwriter template doesn't use this
     shareGooglePlus = false
     shareLinkedIn = false
     dateFormat = "Mon, Jan 2, 2006"
+    utterancesRepo = "markally/blog"
 
 [Permalinks]
     posts = "/:year/:month/:day/:filename/"


### PR DESCRIPTION
Upgrade ghostwriter theme to use own fork at current master, and add utterances comments support to theme. Note that the parameters are hardcoded to this blog.
Add utterances comments to blog. 